### PR TITLE
Fix lag in editor

### DIFF
--- a/css/jscene.css
+++ b/css/jscene.css
@@ -12,6 +12,8 @@ iframe {
 }
 .CodeMirror {
     max-width: 500px;
+}
+.lt-ie9 .CodeMirror {
     width: 500px;
 }
 #sampleCode {

--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<!--[if lt IE 9]><html class="lt-ie9" id=""> <![endif]-->
 <html lang="en">
     <head>
         <meta charset="utf-8">


### PR DESCRIPTION
I'm seeing weird lagging in Chrome - traced it to a CSS class on the CodeMirror div. Have moved the styling to a parent div which fixes it for me. Will need to be tested on other browsers.
